### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/serverless-backend.yaml
+++ b/templates/serverless-backend.yaml
@@ -55,7 +55,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: RequestUnicorn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt RequestUnicornExecutionRole.Arn
       Timeout: 5
       MemorySize: 128


### PR DESCRIPTION
CloudFormation templates in amazon-cognito-identity-management-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.